### PR TITLE
fix: remove debugging from methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 description = "Remembering so you don't have to: simple CLI to quickly access Obsidian vaults in the terminal."
 

--- a/src/app_config/mod.rs
+++ b/src/app_config/mod.rs
@@ -69,7 +69,6 @@ impl AppConfig {
             if !path.is_absolute() {
                 path = std::path::absolute(path)?;
             }
-            dbg!(&path);
             return Ok(Some(path));
         }
         Ok(None)

--- a/src/app_config/tests.rs
+++ b/src/app_config/tests.rs
@@ -83,7 +83,6 @@ fn test_absolute_template_path() -> anyhow::Result<()> {
             periodical: toml::de::from_str::<TomlPeriod>(s)?.0,
         };
         let got = config.try_format_absolute_template_path(*period)?;
-        dbg!(&got);
 
         match got {
             None => assert!(want.is_none(), "Expeted None: {desc}"),


### PR DESCRIPTION
Patch stops debugging of full paths from being printed out in the release version.
