### PR TITLE
feat: template periodical links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "second-brain"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "second-brain"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 description = "Remembering so you don't have to: simple CLI to quickly access Obsidian vaults in the terminal."
 

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 build:
-    cargo build
+    nix build
 
 test:
     cargo test

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -9,7 +9,7 @@ in {
     packages = {
       ${pname} = pkgs.rustPlatform.buildRustPackage {
         inherit pname;
-        version = "0.3.2";
+        version = "0.4.0";
         cargoLock.lockFile = ../Cargo.lock;
         src = pkgs.lib.cleanSource ../.;
       };

--- a/src/app_config/mod.rs
+++ b/src/app_config/mod.rs
@@ -45,6 +45,7 @@ impl AppConfig {
     pub fn try_format_absolute_note_path(
         &self,
         period: Periodical,
+        date: DateTime<Local>,
     ) -> Result<PathBuf, RuntimeError> {
         let parent_dir = self.get_parent_dir(period);
 
@@ -53,7 +54,7 @@ impl AppConfig {
                 .periodical
                 .get(&period)
                 .unwrap_or(&PeriodConfig::default())
-                .format(period, Local::now());
+                .format(period, date);
 
             format!("{name}.md")
         };

--- a/src/app_config/mod.rs
+++ b/src/app_config/mod.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use chrono::Local;
+use chrono::{DateTime, Local};
 use serde::Deserialize;
 
 use crate::{periodic_config::PeriodConfig, prelude::*};
@@ -17,7 +17,7 @@ mod test_cases;
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct AppConfig {
     vault: PathBuf,
     periodical: HashMap<Periodical, PeriodConfig>,
@@ -38,6 +38,14 @@ impl AppConfig {
     }
     pub fn get_vault_root(&self) -> &Path {
         &self.vault
+    }
+    /// Formats the date with interior periodical configurations
+    /// Uses the default formatting configurations if none exists.
+    pub fn format_date(&self, period: Periodical, date: DateTime<Local>) -> String {
+        self.periodical
+            .get(&period)
+            .unwrap_or(&PeriodConfig::default())
+            .format(period, date)
     }
     /// Attempts to format and return the absolute path of a note file.
     /// Returns `${VAULT_ROOT}/${DEFAULT_FILE_NAME_FORMAT}.md` if

--- a/src/app_config/mod.rs
+++ b/src/app_config/mod.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use chrono::Local;
 use serde::Deserialize;
 
 use crate::{periodic_config::PeriodConfig, prelude::*};
@@ -46,11 +47,16 @@ impl AppConfig {
         period: Periodical,
     ) -> Result<PathBuf, RuntimeError> {
         let parent_dir = self.get_parent_dir(period);
-        let file_name = self
-            .periodical
-            .get(&period)
-            .unwrap_or(&PeriodConfig::default())
-            .format_file_name(period);
+
+        let file_name = {
+            let name = self
+                .periodical
+                .get(&period)
+                .unwrap_or(&PeriodConfig::default())
+                .format(period, Local::now());
+
+            format!("{name}.md")
+        };
         let mut full_path = parent_dir.join(file_name);
 
         if full_path.is_relative() {

--- a/src/app_config/tests.rs
+++ b/src/app_config/tests.rs
@@ -219,11 +219,13 @@ fn test_de_filename() -> anyhow::Result<()> {
             .periodical
             .unwrap_or_default()
             .0;
+        let date = Local::now();
         let got = got
             .get(&period)
             .unwrap_or(&PeriodConfig::default())
-            .format_file_name(period);
-        assert_eq!(format!("{want}.md"), got, "{desc}");
+            .format(period, date);
+
+        assert_eq!(want.to_string(), got, "{desc}");
         anyhow::Ok(())
     })
 }

--- a/src/app_config/tests.rs
+++ b/src/app_config/tests.rs
@@ -46,7 +46,7 @@ fn test_absoulute_note_path() -> anyhow::Result<()> {
             vault: "./vaults".into(),
             periodical: toml::de::from_str::<TomlPeriod>(s)?.0,
         };
-        let got = config.try_format_absolute_note_path(*period)?;
+        let got = config.try_format_absolute_note_path(*period, Local::now())?;
         let file_name = Local::now().format(want).to_string();
 
         assert!(got.to_string_lossy().contains(&file_name), "{desc}");

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -118,10 +118,9 @@ mod test {
         ];
 
         test_cases.into_iter().for_each(|(period, interval, want)| {
-            let fmt = config.get_format(period);
             let got = period
                 .get_next(date, interval)
-                .map(|f| f.format(fmt).to_string());
+                .map(|f| config.format(period, f));
 
             assert_eq!(Some(want.to_string()), got)
         });
@@ -140,10 +139,9 @@ mod test {
         ];
 
         test_cases.into_iter().for_each(|(period, interval, want)| {
-            let fmt = config.get_format(period);
             let got = period
                 .get_prev(date, interval)
-                .map(|f| f.format(fmt).to_string());
+                .map(|f| config.format(period, f));
 
             assert_eq!(Some(want.to_string()), got)
         });

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -37,10 +37,11 @@ pub enum Periodical {
 
 impl Periodical {
     pub fn open(&self, config: &AppConfig) -> Result<(), Status> {
-        let path = config.try_format_absolute_note_path(*self)?;
+        let date = Local::now();
+        let path = config.try_format_absolute_note_path(*self, date)?;
         // write file if it doesn't exist
         if !path.exists() {
-            self.write(config, &path)?;
+            self.write(config, &path, date)?;
         }
         // open file in editor
         let editor = std::env::var("EDITOR").unwrap_or("nvim".into());
@@ -52,14 +53,19 @@ impl Periodical {
 
         Ok(())
     }
-    fn write(&self, config: &AppConfig, path: &Path) -> Result<(), Status> {
+    fn write(&self, config: &AppConfig, path: &Path, date: DateTime<Local>) -> Result<(), Status> {
         let mut contents = Vec::<u8>::new();
+        if let Some(heading) = self.try_format_heading(config, date) {
+            contents.append(&mut heading.into());
+            contents.append(&mut "\n\n".to_string().into());
+        }
         if let Some(template_path) = config.try_format_absolute_template_path(*self)? {
             // validate template before reading
             if !template_path.is_file() {
                 return Err(ConfigError::InvalidFile(template_path).into());
             }
-            contents = std::fs::read(template_path).map_err(RuntimeError::Io)?;
+            let mut template = std::fs::read(template_path).map_err(RuntimeError::Io)?;
+            contents.append(&mut template);
         }
         // create any necessary parent dirs
         if let Some(parent_path) = path.parent() {
@@ -82,7 +88,7 @@ impl Periodical {
     /// Given a start date and an interval of Periodcals expressed as an uint,
     /// will calculate the next interval date in time
     /// with the correct formatting.
-    pub fn get_next(&self, date: DateTime<Local>, interval: u32) -> Option<DateTime<Local>> {
+    fn get_next(&self, date: DateTime<Local>, interval: u32) -> Option<DateTime<Local>> {
         match self {
             Periodical::Day => date.checked_add_days(Days::new(u64::from(interval))),
             Periodical::Week => date.checked_add_days(Days::new(u64::from(interval * 7))),
@@ -93,7 +99,7 @@ impl Periodical {
     /// Given a start date and an interval of Periodcals expressed as an uint,
     /// will calculate the next interval date in time
     /// with the correct formatting.
-    pub fn get_prev(&self, date: DateTime<Local>, interval: u32) -> Option<DateTime<Local>> {
+    fn get_prev(&self, date: DateTime<Local>, interval: u32) -> Option<DateTime<Local>> {
         match self {
             Periodical::Day => date.checked_sub_days(Days::new(u64::from(interval))),
             Periodical::Week => date.checked_sub_days(Days::new(u64::from(interval * 7))),

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -1,5 +1,6 @@
 use std::{io::Write, path::Path};
 
+use chrono::{DateTime, Days, Local, Months};
 use clap::Parser;
 use serde::Deserialize;
 use strum_macros::{Display, EnumString, VariantNames};
@@ -71,5 +72,80 @@ impl Periodical {
             f.write(&contents).map_err(RuntimeError::Io)?;
         }
         Ok(())
+    }
+
+    /// Given a start date and an interval of Periodcals expressed as an uint,
+    /// will calculate the next interval date in time
+    /// with the correct formatting.
+    pub fn get_next(&self, date: DateTime<Local>, interval: u32) -> Option<DateTime<Local>> {
+        match self {
+            Periodical::Day => date.checked_add_days(Days::new(u64::from(interval))),
+            Periodical::Week => date.checked_add_days(Days::new(u64::from(interval * 7))),
+            Periodical::Month => date.checked_add_months(Months::new(interval)),
+            Periodical::Year => date.checked_add_months(Months::new(interval * 12)),
+        }
+    }
+    /// Given a start date and an interval of Periodcals expressed as an uint,
+    /// will calculate the next interval date in time
+    /// with the correct formatting.
+    pub fn get_prev(&self, date: DateTime<Local>, interval: u32) -> Option<DateTime<Local>> {
+        match self {
+            Periodical::Day => date.checked_sub_days(Days::new(u64::from(interval))),
+            Periodical::Week => date.checked_sub_days(Days::new(u64::from(interval * 7))),
+            Periodical::Month => date.checked_sub_months(Months::new(interval)),
+            Periodical::Year => date.checked_sub_months(Months::new(interval * 12)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use chrono::TimeZone;
+
+    use super::super::periodic_config::PeriodConfig;
+    use super::*;
+
+    #[test]
+    fn test_get_next() {
+        let date = Local.with_ymd_and_hms(2025, 12, 30, 0, 0, 0).unwrap();
+        let config = PeriodConfig::default();
+
+        let test_cases = [
+            (Periodical::Day, 1, "2025-12-31"),
+            (Periodical::Week, 1, "2026-W02"),
+            (Periodical::Month, 1, "2026-01"),
+            (Periodical::Year, 2, "2027"),
+        ];
+
+        test_cases.into_iter().for_each(|(period, interval, want)| {
+            let fmt = config.get_format(period);
+            let got = period
+                .get_next(date, interval)
+                .map(|f| f.format(fmt).to_string());
+
+            assert_eq!(Some(want.to_string()), got)
+        });
+    }
+
+    #[test]
+    fn test_get_prev() {
+        let date = Local.with_ymd_and_hms(2025, 12, 30, 0, 0, 0).unwrap();
+        let config = PeriodConfig::default();
+
+        let test_cases = [
+            (Periodical::Day, 1, "2025-12-29"),
+            (Periodical::Week, 1, "2025-W52"),
+            (Periodical::Month, 10, "2025-02"),
+            (Periodical::Year, 2, "2023"),
+        ];
+
+        test_cases.into_iter().for_each(|(period, interval, want)| {
+            let fmt = config.get_format(period);
+            let got = period
+                .get_prev(date, interval)
+                .map(|f| f.format(fmt).to_string());
+
+            assert_eq!(Some(want.to_string()), got)
+        });
     }
 }

--- a/src/periodic.rs
+++ b/src/periodic.rs
@@ -73,7 +73,12 @@ impl Periodical {
         }
         Ok(())
     }
+    fn try_format_heading(&self, config: &AppConfig, date: DateTime<Local>) -> Option<String> {
+        let prev = config.format_date(*self, self.get_prev(date, 1)?);
+        let next = config.format_date(*self, self.get_next(date, 1)?);
 
+        Some(format!("[[{prev}]] - [[{next}]]"))
+    }
     /// Given a start date and an interval of Periodcals expressed as an uint,
     /// will calculate the next interval date in time
     /// with the correct formatting.
@@ -144,6 +149,24 @@ mod test {
                 .map(|f| config.format(period, f));
 
             assert_eq!(Some(want.to_string()), got)
+        });
+    }
+    #[test]
+    fn test_headings() {
+        let desc = "Test template heading genereation";
+        let date = Local.with_ymd_and_hms(2025, 12, 30, 0, 0, 0).unwrap();
+        let config = AppConfig::default();
+
+        let test_cases = [
+            (Periodical::Day, "[[2025-12-29]] - [[2025-12-31]]"),
+            (Periodical::Week, "[[2025-W52]] - [[2026-W02]]"),
+            (Periodical::Month, "[[2025-11]] - [[2026-01]]"),
+            (Periodical::Year, "[[2024]] - [[2026]]"),
+        ];
+
+        test_cases.into_iter().for_each(|(period, want)| {
+            let got = period.try_format_heading(&config, date);
+            assert_eq!(Some(want.into()), got, "{desc}: {period}")
         });
     }
 }

--- a/src/periodic_config.rs
+++ b/src/periodic_config.rs
@@ -1,4 +1,4 @@
-use chrono::Local;
+use chrono::{DateTime, Datelike, Local};
 use serde::Deserialize;
 
 use crate::prelude::*;
@@ -21,63 +21,79 @@ impl PeriodConfig {
     pub fn get_template_file(&self) -> Option<&str> {
         Some(self.template.as_ref()?.as_str())
     }
-    /// Takes the current date and a given Periodical and formats a filename
-    pub fn format_file_name(&self, period: Periodical) -> String {
-        let name = Local::now().format(self.get_format(period));
-        format!("{name}.md")
-    }
     /// Attempts to get the configured file name associated with
     /// this Periodical.
     /// Returns a default format if not configured.
-    pub fn get_format(&self, period: Periodical) -> &str {
-        self.fmt.as_deref().unwrap_or(match period {
+    pub fn format(&self, period: Periodical, date: DateTime<Local>) -> String {
+        let fmt = self.fmt.as_deref().unwrap_or(match period {
             Periodical::Day => DEFAULT_DAY,
             Periodical::Week => DEFAULT_WEEK,
             Periodical::Month => DEFAULT_MONTH,
             Periodical::Year => DEFAULT_YEAR,
-        })
+        });
+        if matches!(period, Periodical::Week) {
+            let year = date.iso_week().year();
+            let year = match year.abs() < 10 {
+                true => format!("0{year}"),
+                false => year.to_string(),
+            };
+            let week = date.iso_week().week();
+            let week = match week < 10 {
+                true => format!("0{week}"),
+                false => week.to_string(),
+            };
+            let res = fmt.replace("%Y", &year);
+            let res = res.replace("%V", &week);
+            return res;
+        }
+        date.format(fmt).to_string()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use chrono::TimeZone;
+
     use super::*;
 
     #[test]
-    fn test_default_filename() {
-        let test_cases = [
-            (Periodical::Day, DEFAULT_DAY, "test default day config"),
-            (Periodical::Week, DEFAULT_WEEK, "test default week config"),
-            (
-                Periodical::Month,
-                DEFAULT_MONTH,
-                "test default month config",
-            ),
-            (Periodical::Year, DEFAULT_YEAR, "test default year config"),
-        ];
+    fn test_default_formatter() {
+        let desc = "Test default configs";
+        let date = Local.with_ymd_and_hms(2025, 12, 30, 0, 0, 0).unwrap();
         let config = PeriodConfig::default();
 
-        test_cases.into_iter().for_each(|(period, fmt, desc)| {
-            let want = format!("{}.md", Local::now().format(fmt));
-            let got = config.format_file_name(period);
-            assert_eq!(want, got, "{desc}");
+        let test_cases = [
+            (Periodical::Day, "2025-12-30"),
+            (Periodical::Week, "2026-W01"),
+            (Periodical::Month, "2025-12"),
+            (Periodical::Year, "2025"),
+        ];
+
+        test_cases.into_iter().for_each(|(period, want)| {
+            let got = config.format(period, date);
+            assert_eq!(want, got, "{desc}: {period}");
         });
     }
 
     #[test]
     fn test_mixed_configs_filename() {
+        let desc = "Test a mix of configured and unconfigrued date formats";
+        let date = Local.with_ymd_and_hms(2025, 12, 30, 0, 0, 0).unwrap();
         let test_cases = [
-            (Periodical::Day, "%m-%d-%Y", "test configured day fmt"),
-            (Periodical::Week, DEFAULT_WEEK, "test unconfigured week fmt"),
-            (Periodical::Month, "%m", "test fully configured month"),
-            (Periodical::Year, DEFAULT_YEAR, "test unconfigured year"),
+            (Periodical::Day, "12-30-2025", "configured day"),
+            (Periodical::Week, "01-2026", "configured week"),
+            (Periodical::Month, "12", "configured month"),
+            (Periodical::Year, "2025", "test unconfigured year"),
         ];
         let config = [
             PeriodConfig {
                 fmt: Some("%m-%d-%Y".into()),
                 ..Default::default()
             },
-            PeriodConfig::default(),
+            PeriodConfig {
+                fmt: Some("%V-%Y".into()),
+                ..Default::default()
+            },
             PeriodConfig {
                 fmt: Some("%m".into()),
                 ..Default::default()
@@ -87,10 +103,9 @@ mod tests {
         test_cases
             .into_iter()
             .zip(config)
-            .for_each(|((period, fmt, desc), config)| {
-                let want = format!("{}.md", Local::now().format(fmt));
-                let got = config.format_file_name(period);
-                assert_eq!(want, got, "{desc}");
+            .for_each(|((period, want, case), config)| {
+                let got = config.format(period, date);
+                assert_eq!(want, got, "{desc}: {case} {period}");
             });
     }
 }

--- a/src/periodic_config.rs
+++ b/src/periodic_config.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Days, Local, Months};
+use chrono::Local;
 use serde::Deserialize;
 
 use crate::prelude::*;
@@ -29,7 +29,7 @@ impl PeriodConfig {
     /// Attempts to get the configured file name associated with
     /// this Periodical.
     /// Returns a default format if not configured.
-    fn get_format(&self, period: Periodical) -> &str {
+    pub fn get_format(&self, period: Periodical) -> &str {
         self.fmt.as_deref().unwrap_or(match period {
             Periodical::Day => DEFAULT_DAY,
             Periodical::Week => DEFAULT_WEEK,
@@ -37,50 +37,10 @@ impl PeriodConfig {
             Periodical::Year => DEFAULT_YEAR,
         })
     }
-    /// Given a start date and an interval of Periodcals expressed as an uint,
-    /// will calculate the next interval date in time
-    /// with the correct formatting.
-    pub fn get_next(
-        &self,
-        date: DateTime<Local>,
-        interval: u32,
-        period: Periodical,
-    ) -> Option<String> {
-        let res = match period {
-            Periodical::Day => date.checked_add_days(Days::new(u64::from(interval))),
-            Periodical::Week => date.checked_add_days(Days::new(u64::from(interval * 7))),
-            Periodical::Month => date.checked_add_months(Months::new(interval)),
-            Periodical::Year => date.checked_add_months(Months::new(interval * 12)),
-        };
-
-        let fmt = self.get_format(period);
-        res.map(|f| f.format(fmt).to_string())
-    }
-    /// Given a start date and an interval of Periodcals expressed as an uint,
-    /// will calculate the next interval date in time
-    /// with the correct formatting.
-    pub fn get_prev(
-        &self,
-        date: DateTime<Local>,
-        interval: u32,
-        period: Periodical,
-    ) -> Option<String> {
-        let res = match period {
-            Periodical::Day => date.checked_sub_days(Days::new(u64::from(interval))),
-            Periodical::Week => date.checked_sub_days(Days::new(u64::from(interval * 7))),
-            Periodical::Month => date.checked_sub_months(Months::new(interval)),
-            Periodical::Year => date.checked_sub_months(Months::new(interval * 12)),
-        };
-
-        let fmt = self.get_format(period);
-        res.map(|f| f.format(fmt).to_string())
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use chrono::TimeZone;
-
     use super::*;
 
     #[test]
@@ -132,41 +92,5 @@ mod tests {
                 let got = config.format_file_name(period);
                 assert_eq!(want, got, "{desc}");
             });
-    }
-
-    #[test]
-    fn test_get_next() {
-        let date = Local.with_ymd_and_hms(2025, 12, 30, 0, 0, 0).unwrap();
-        let config = PeriodConfig::default();
-
-        let test_cases = [
-            (Periodical::Day, 1, "2025-12-31"),
-            (Periodical::Week, 1, "2026-W02"),
-            (Periodical::Month, 1, "2026-01"),
-            (Periodical::Year, 2, "2027"),
-        ];
-
-        test_cases.into_iter().for_each(|(period, interval, want)| {
-            let got = config.get_next(date, interval, period);
-            assert_eq!(Some(want.to_string()), got)
-        });
-    }
-
-    #[test]
-    fn test_get_prev() {
-        let date = Local.with_ymd_and_hms(2025, 12, 30, 0, 0, 0).unwrap();
-        let config = PeriodConfig::default();
-
-        let test_cases = [
-            (Periodical::Day, 1, "2025-12-29"),
-            (Periodical::Week, 1, "2025-W52"),
-            (Periodical::Month, 10, "2025-02"),
-            (Periodical::Year, 2, "2023"),
-        ];
-
-        test_cases.into_iter().for_each(|(period, interval, want)| {
-            let got = config.get_prev(date, interval, period);
-            assert_eq!(Some(want.to_string()), got)
-        });
     }
 }

--- a/src/periodic_config.rs
+++ b/src/periodic_config.rs
@@ -1,4 +1,4 @@
-use chrono::Local;
+use chrono::{DateTime, Days, Local, Months};
 use serde::Deserialize;
 
 use crate::prelude::*;
@@ -21,24 +21,66 @@ impl PeriodConfig {
     pub fn get_template_file(&self) -> Option<&str> {
         Some(self.template.as_ref()?.as_str())
     }
+    /// Takes the current date and a given Periodical and formats a filename
+    pub fn format_file_name(&self, period: Periodical) -> String {
+        let name = Local::now().format(self.get_format(period));
+        format!("{name}.md")
+    }
     /// Attempts to get the configured file name associated with
     /// this Periodical.
     /// Returns a default format if not configured.
-    pub fn format_file_name(&self, period: Periodical) -> String {
-        let fmt = self.fmt.as_deref().unwrap_or(match period {
+    fn get_format(&self, period: Periodical) -> &str {
+        self.fmt.as_deref().unwrap_or(match period {
             Periodical::Day => DEFAULT_DAY,
             Periodical::Week => DEFAULT_WEEK,
             Periodical::Month => DEFAULT_MONTH,
             Periodical::Year => DEFAULT_YEAR,
-        });
-        let name = Local::now().format(fmt);
+        })
+    }
+    /// Given a start date and an interval of Periodcals expressed as an uint,
+    /// will calculate the next interval date in time
+    /// with the correct formatting.
+    pub fn get_next(
+        &self,
+        date: DateTime<Local>,
+        interval: u32,
+        period: Periodical,
+    ) -> Option<String> {
+        let res = match period {
+            Periodical::Day => date.checked_add_days(Days::new(u64::from(interval))),
+            Periodical::Week => date.checked_add_days(Days::new(u64::from(interval * 7))),
+            Periodical::Month => date.checked_add_months(Months::new(interval)),
+            Periodical::Year => date.checked_add_months(Months::new(interval * 12)),
+        };
 
-        format!("{name}.md")
+        let fmt = self.get_format(period);
+        res.map(|f| f.format(fmt).to_string())
+    }
+    /// Given a start date and an interval of Periodcals expressed as an uint,
+    /// will calculate the next interval date in time
+    /// with the correct formatting.
+    pub fn get_prev(
+        &self,
+        date: DateTime<Local>,
+        interval: u32,
+        period: Periodical,
+    ) -> Option<String> {
+        let res = match period {
+            Periodical::Day => date.checked_sub_days(Days::new(u64::from(interval))),
+            Periodical::Week => date.checked_sub_days(Days::new(u64::from(interval * 7))),
+            Periodical::Month => date.checked_sub_months(Months::new(interval)),
+            Periodical::Year => date.checked_sub_months(Months::new(interval * 12)),
+        };
+
+        let fmt = self.get_format(period);
+        res.map(|f| f.format(fmt).to_string())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use chrono::TimeZone;
+
     use super::*;
 
     #[test]
@@ -90,5 +132,41 @@ mod tests {
                 let got = config.format_file_name(period);
                 assert_eq!(want, got, "{desc}");
             });
+    }
+
+    #[test]
+    fn test_get_next() {
+        let date = Local.with_ymd_and_hms(2025, 12, 30, 0, 0, 0).unwrap();
+        let config = PeriodConfig::default();
+
+        let test_cases = [
+            (Periodical::Day, 1, "2025-12-31"),
+            (Periodical::Week, 1, "2026-W02"),
+            (Periodical::Month, 1, "2026-01"),
+            (Periodical::Year, 2, "2027"),
+        ];
+
+        test_cases.into_iter().for_each(|(period, interval, want)| {
+            let got = config.get_next(date, interval, period);
+            assert_eq!(Some(want.to_string()), got)
+        });
+    }
+
+    #[test]
+    fn test_get_prev() {
+        let date = Local.with_ymd_and_hms(2025, 12, 30, 0, 0, 0).unwrap();
+        let config = PeriodConfig::default();
+
+        let test_cases = [
+            (Periodical::Day, 1, "2025-12-29"),
+            (Periodical::Week, 1, "2025-W52"),
+            (Periodical::Month, 10, "2025-02"),
+            (Periodical::Year, 2, "2023"),
+        ];
+
+        test_cases.into_iter().for_each(|(period, interval, want)| {
+            let got = config.get_prev(date, interval, period);
+            assert_eq!(Some(want.to_string()), got)
+        });
     }
 }


### PR DESCRIPTION
PR adds new feature: when writing a new file, the previous and next periodical not will be added as links automatically at the top of the note.

Serveral internal changes were made to decouple using the current date in all the `AppConfig` and `PeriodicalConig` structs. This allowed refactoring tests to test specific dates and periods.

✨ New features:

- **feat: add functions to get relative date-times for PeriodConfig**
- **feat: add public method for AppConfig for general date formatting**
- **feat: writing new files creates links to previous and next Periodical**

🐛 Bug fixes:

- **fix: formatting weeks now uses IsoWeek as base instead of Local (fixes #9)**
